### PR TITLE
Override inherited text-align

### DIFF
--- a/d2l-loading-spinner.html
+++ b/d2l-loading-spinner.html
@@ -7,6 +7,7 @@
 			:host {
 				color: var(--d2l-loading-spinner-color, --d2l-color-celestine);
 				display: inline-block;
+				text-align: initial;
 			}
 
 			:host .d2l-loading-spinner-wrapper {


### PR DESCRIPTION
If the spinner inherits `text-align: center`, you get this:
![](https://media.giphy.com/media/TjNqNUiouVGMw/giphy.gif)