### PR TITLE
Hiding spinner when hidden attribute is present

### DIFF
--- a/d2l-loading-spinner.html
+++ b/d2l-loading-spinner.html
@@ -14,6 +14,10 @@
 				display: inline-block;
 				text-align: initial;
 			}
+			/* required since display of inline-block is non-default */
+			:host([hidden]) {
+				display: none;
+			}
 
 			:host .d2l-loading-spinner-wrapper {
 				height: var(--d2l-loading-spinner-size, 50px);


### PR DESCRIPTION
Required since its display of `inline-block` is non-default.